### PR TITLE
Ajout de la souscription aux listes de diffusion à la création de compte

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -7,6 +7,8 @@
 
 This template is based on ruby version 2.1.2p95 (2014-05-08 revision 45877)
 
+Note that Continuous Integration (Travis) ruby version 2.2.2p95 (2015-04-13 revision 50295)
+
 === System dependencies
 
 No specific system dependencies
@@ -90,6 +92,12 @@ All password are : *password*
 === Testing
 
 This template use RSpec for testing
+
+  bundle exec rspec --format doc
+
+Cucumber
+
+  bundle exec cucumber
 
 === Update 
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -11,11 +11,35 @@ This template is based on ruby version 2.1.2p95 (2014-05-08 revision 45877)
 
 No specific system dependencies
 
+  bundle install
+
+If you need to setup a local rabbitMQ instance with docker and default configuration,
+checkout https://github.com/gadzorg/gram2_api_server and launch :
+
+  docker run  --name gram-rabbitmq -p 5672:5672 rabbitmq
+
+If the docker image already exists :
+
+  docker start gram-rabbitmq
+  docker logs -f gram-rabbitmq
+
 === Initial Configuration
 
 Before first use, you need to configure /config/secrets.yml
 
-An example file is available in /config/secretes.yml.template
+An example file is available in /config/secrets.yml.template
+
+  gram_api_site: "https://example-gram-api.domain.com/api/v2/"
+  gram_api_user: "xxxx"
+  gram_api_password: "****"
+  cas_provider_url: "auth-example.domain.com"
+
+You also need to configure /config/rabbitmq.yml
+
+An example file is available in /config/rabbitmq.yml.template
+
+You might also need to touch /config/configurable.yml in order to set
+legacy_auth_enabled to false if you need to connect to CAS server.
 
 === Database creation
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -99,6 +99,9 @@ Cucumber
 
   bundle exec cucumber
 
+Don't forget to configure the test section of /config/secrets.yml with fake 
+gram credentials, and api_user/api_password too.
+
 === Update 
 
 ==== UI update (commit c3909ed)

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -6,11 +6,15 @@ class SetupController < ApplicationController
 
   layout 'no-menu'
 
+  # GET /setup
   def index
     @service.prepare
     @primary_email = @user.primary_email.to_s
+    @mailing_lists = @setup_subscription_service.mailing_lists
   end
 
+  # POST /setup
+  # When accepting creating @gadz.org email
   def setup
     respond_to do |format|
       begin
@@ -29,6 +33,7 @@ class SetupController < ApplicationController
 
   end
 
+  # GET /setup/finish
   def finish
   end
 
@@ -39,11 +44,16 @@ private
   end
 
   def set_service
-    @service=SetupService.new(@user)
+    @setup_subscription_service = SetupSubscriptionService.new(@user)
+    @service = SetupService.new(@user, setup_subscription_service: @setup_subscription_service)
   end
 
   def setup_params
-    params.permit(:google_apps, :redirect)
+    params.permit(
+      :google_apps,
+      :redirect,
+      :default_mls,
+    )
   end
 
   def check_setup_need

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -164,8 +164,9 @@ class User < ActiveRecord::Base
         self.last_gram_sync_at = Time.now
         self.hruid = gram_data.hruid
         self.is_gadz = gram_data.is_gadz
-        self.gadz_proms_principale = gram_data.gadz_proms_principale # ex: "2017"
-        self.gadz_centre_principal = gram_data.gadz_centre_principal # ex: "bo"
+        # use try to prevent from issue if GorgMail is released before GrAM
+        self.gadz_proms_principale = gram_data.try(:gadz_proms_principale) # ex: "2017"
+        self.gadz_centre_principal = gram_data.try(:gadz_centre_principal) # ex: "bo"
 
         if self.save
           self.synced_with_gram = true 

--- a/app/services/setup_subscription_service.rb
+++ b/app/services/setup_subscription_service.rb
@@ -1,0 +1,70 @@
+class SetupSubscriptionService
+  attr_reader :user, :mailing_lists
+
+  def initialize(user)
+    @user = user
+    @mailing_lists = {}
+
+    build_mailing_lists
+  end
+
+  def do_subscribe
+    mailing_lists.each do |ml_key, mailing_list|
+      service = MailingListSubscriptionService.new(list: mailing_list, user: user)
+      service.do_subscribe
+    end
+  end
+
+  [:proms, :tabagns, :info].each do |prefix|
+    define_method "#{prefix}_mailing_list" do
+      mailing_lists[prefix]
+    end
+  end
+
+  private
+
+  def build_mailing_lists
+    add_mailing_list :proms, proms_mailing_list_email
+    add_mailing_list :tabagns, tabagns_mailing_list_email
+    add_mailing_list :info, info_mailing_list_email
+  end
+
+  def add_mailing_list(ml_key, email)
+    ml = Ml::List.find_by(email: email)
+    @mailing_lists[ml_key] = ml if ml
+  end
+
+  # La mailing list de Promotion
+  # Exemple : bordeaux + 2017 => bo217@gadz.org
+  def proms_mailing_list_email
+    "#{gadz_tabagns}#{gadz_ans}@gadz.org"
+  end
+
+  # La mailing list du Tabagn’s
+  # Exemple : bordeaux => tbk.bo@gadz.org, aix => tbk.kin@gadz.org
+  def tabagns_mailing_list_email
+    "tbk.#{gadz_tabagns}@gadz.org"
+  end
+
+  # La mailing list d’information
+  def info_mailing_list_email
+    "info-pg@gadz.org"
+  end
+
+  # User "Tabagn's"
+  # ex: an, bo, ch, cl, ka, li, me, kin (ai)
+  # Note: exception for Aix(ai) : kin
+  def gadz_tabagns
+    case user.gadz_centre_principal
+      when 'ai' then 'kin'
+      else user.gadz_centre_principal
+    end
+  end
+  
+  # User "an's"
+  # ex: "1998"->"198" , "2017"->"217"
+  # Note: expected year >= 1947 
+  def gadz_ans
+    (user.gadz_proms_principale.to_i - 1800).to_s
+  end
+end

--- a/app/views/setup/index.html.haml
+++ b/app/views/setup/index.html.haml
@@ -3,12 +3,12 @@
 
 =form_tag('') do
   .row
-    .l6.s12.col
+    .l12.s12.col
       %p
         Il nous manque quelques informations pour finaliser ton compte.
 
   .row
-    .l6.s12.col
+    .l12.s12.col
 
       .card
         .card-content
@@ -28,6 +28,20 @@
             .input-field.inline
               =email_field_tag :redirect,nil, :size => 40, :required => 'required', :class=> 'validate'
               =label_tag("redirect", "Mon adresse email", "data-error"=>"Tu dois entrer ton adresse email au format email@domaine.fr", required: true)
+
+        - if @mailing_lists.any?
+          .card-content(style="padding-top:0")
+            %p Pour tirer un plein parti de tes adresses gadz.org, nous te recommandons de t'inscrire aux trois listes de diffusions suivantes :
+
+            %ul.browser-default
+              %li Pour échanger avec tes Promsquets, ta ML de Prom's : <u>#{@mailing_lists[:proms]&.email}</u>
+              %li Pour recevoir les infos de ton Tabagn's vers les PGs : <u>#{@mailing_lists[:tabagns]&.email}</u>
+              %li Pour recevoir les infos de l'UE vers les PGs : <u>#{@mailing_lists[:info]&.email}</u>
+
+            .input-field
+              =check_box_tag :default_mls, "true", 1
+              =label_tag :default_mls, "Je veux m'inscrire à ces 3 listes de diffusion", :for => "default_mls"
+
         .card-action
           =button_tag "Créer mon compte", class:'waves-effect waves-teal btn'
 

--- a/app/views/setup/index.html.haml
+++ b/app/views/setup/index.html.haml
@@ -34,9 +34,9 @@
             %p Pour tirer un plein parti de tes adresses gadz.org, nous te recommandons de t'inscrire aux trois listes de diffusions suivantes :
 
             %ul.browser-default
-              %li Pour échanger avec tes Promsquets, ta ML de Prom's : <u>#{@mailing_lists[:proms]&.email}</u>
-              %li Pour recevoir les infos de ton Tabagn's vers les PGs : <u>#{@mailing_lists[:tabagns]&.email}</u>
-              %li Pour recevoir les infos de l'UE vers les PGs : <u>#{@mailing_lists[:info]&.email}</u>
+              %li Pour échanger avec tes Promsquets, ta ML de Prom's : <u>#{@mailing_lists[:proms] ? @mailing_lists[:proms].email : '-'}</u>
+              %li Pour recevoir les infos de ton Tabagn's vers les PGs : <u>#{@mailing_lists[:tabagns] ? @mailing_lists[:tabagns].email : '-'}</u>
+              %li Pour recevoir les infos de l'UE vers les PGs : <u>#{@mailing_lists[:info] ? @mailing_lists[:info].email : '-'}</u>
 
             .input-field
               =check_box_tag :default_mls, "true", 1

--- a/db/migrate/20180222171919_add_gadz_centre_and_gadz_proms_to_users.rb
+++ b/db/migrate/20180222171919_add_gadz_centre_and_gadz_proms_to_users.rb
@@ -2,6 +2,5 @@ class AddGadzCentreAndGadzPromsToUsers < ActiveRecord::Migration
   def change
     add_column :users, :gadz_centre_principal, :string
     add_column :users, :gadz_proms_principale, :string
-    # add_column :users, :subscribed_to_default_mailing_lists_at, :datetime
   end
 end

--- a/db/migrate/20180222171919_add_gadz_centre_and_gadz_proms_to_users.rb
+++ b/db/migrate/20180222171919_add_gadz_centre_and_gadz_proms_to_users.rb
@@ -1,0 +1,7 @@
+class AddGadzCentreAndGadzPromsToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :gadz_centre_principal, :string
+    add_column :users, :gadz_proms_principale, :string
+    # add_column :users, :subscribed_to_default_mailing_lists_at, :datetime
+  end
+end

--- a/features/common/setup.feature
+++ b/features/common/setup.feature
@@ -25,3 +25,19 @@ Feature: I'm asked to setup my account on first log-in
     Then my redirect address "mon.adresse@example.com" is created
     And my source address "john.doe@gadz.org" is created
     And my googleapps account is created
+    And I should not be subscribed to any mailinglist
+
+  Scenario: I fill the setup form with subscription optout
+    Given I am logged in with a newly created gadz account with firstname "john", lastname "doe", gadz_centre_principal "bo", gadz_proms_principale "2017"
+    And there is a public mailing lists with email "tbk.bo@gadz.org"
+    And there is a public mailing lists with email "bo217@gadz.org"
+    And there is a public mailing lists with email "info-pg@gadz.org"
+    When I visit "/dashboard"
+    And I check box "default_mls"
+    And I fill "redirect" with "mon.adresse@example.com"
+    And I click "Créer mon compte" button
+    Then my redirect address "mon.adresse@example.com" is created
+    And I should be subscribed to 3 mailinglists
+    And I should be subscribed to mailinglist "tbk.bo@gadz.org"
+    And I should be subscribed to mailinglist "bo217@gadz.org"
+    And I should be subscribed to mailinglist "info-pg@gadz.org"

--- a/features/step_definitions/mailing_lists.rb
+++ b/features/step_definitions/mailing_lists.rb
@@ -10,6 +10,15 @@ Given(/^there is a public mailing lists named "([^"]*)"$/) do |arg|
   )
 end
 
+Given(/^there is a public mailing lists with email "([^"]*)"$/) do |arg|
+  @ml=FactoryGirl.create(:ml_list,
+                         name: arg,
+                         email: arg,
+                         diffusion_policy: 'open',
+                         inscription_policy: 'open'
+  )
+end
+
 And(/^there is a group\-only mailing lists named "([^"]*)" for group "([^"]*)"$/) do |arg1, arg2|
   @ml=FactoryGirl.create(:ml_list,
                          name: arg1,
@@ -154,4 +163,16 @@ end
 
 Then(/^user "([^"]*)" should be subscribed to mailinglist "([^"]*)"$/) do |hruid, ml_name|
   expect(Ml::List.find_by(name: ml_name).all_members).to include(User.find_by(hruid: hruid))
+end
+
+Then(/^I should be subscribed to mailinglist "([^"]*)"$/) do |ml_name|
+  expect(Ml::List.find_by(name: ml_name).all_members).to include(@me)
+end
+
+Then(/^I should be subscribed to (\d+) mailinglists$/) do |n|
+  expect(@me.lists.size).to eq(n.to_i)
+end
+
+Then(/^I should not be subscribed to any mailinglist$/) do
+  expect(@me.lists).to be_empty
 end

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -13,7 +13,9 @@ namespace :db do
     Rake::Task['db:reset'].invoke
 
     # Create admin_user account
+    # L'identifiant Agoram (hruid) doit être rempli(e)
     admin_user = User.create!(:email => "admin@poubs.org",
+                              :hruid => 'prenom.nom.9901',
                               :firstname => Faker::Name.first_name,
                               :lastname => Faker::Name.last_name,
                               :password => "password",
@@ -27,6 +29,7 @@ namespace :db do
 
     # Create support_user account
     support_user = User.create!(:email => "support@poubs.org",
+                              :hruid => 'prenom.nom.9902',
                               :firstname => Faker::Name.first_name,
                               :lastname => Faker::Name.last_name,
                               :password => "password",
@@ -42,6 +45,7 @@ namespace :db do
 
     basic_users = (1..3).map do |i|
         User.create!( :email => "user#{i}@poubs.org",
+                      :hruid => "prenom.nom.991#{i}",
                       :firstname => Faker::Name.first_name,
                       :lastname => Faker::Name.last_name,
                       :password => "password",

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -1,5 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe SetupController, type: :controller do
+  include Devise::TestHelpers
+
+  let(:valid_ml_attributes) {
+    skip("Add a hash of attributes valid for your model")
+  }
+
+  let(:valid_session) { {} }
+
+  describe "GET #index" do
+    it "assigns setup ml_lists as @mailing_lists" do
+      list = Ml::List.create! valid_ml_attributes
+      get :index, session: valid_session
+      expect(assigns(:mailing_lists)).to eq([])
+    end
+  end
 
 end

--- a/spec/message_handlers/gram_account_updated_message_handler_spec.rb
+++ b/spec/message_handlers/gram_account_updated_message_handler_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe GramAccountUpdatedMessageHandler, type: :message_handler do
         gadz_fams_zaloeil:[nil,""],
         gadz_proms_principale:[nil,"1986"],
         gadz_proms_secondaire:[nil,""],
+        gadz_centre_principal:[nil,"bo"],
+        gadz_centre_secondaire:[nil,""],
         avatar_url:[nil,"http://recette.soce.fr/images/"],
         url:[nil,"/api/v2/accounts/36a7e016-a300-4f52-85f4-6804dede6c6b"]
      }
@@ -100,12 +102,16 @@ RSpec.describe GramAccountUpdatedMessageHandler, type: :message_handler do
 
     context "not existing gorgmail user" do
 
+      # https://github.com/gadzorg/gram2_api_client_ruby/blob/master/lib/gram_v2_client/rspec/gram_account_mocker.rb
       let(:gam) {GramAccountMocker.for(attr:{uuid: "36a7e016-a300-4f52-85f4-6804dede6c6b",
                                                         email: "bono@gmail.com",
                                                         hruid: "paul.david-hewson.1986",
                                                         firstname: "Paulo",
                                                         lastname: "David",
-                                                        is_gadz: true  },
+                                                        is_gadz: true,
+                                                        gadz_proms_principale: "1986",
+                                                        gadz_centre_principal: "bo"
+                                                  },
                                                   auth: GramAccountMocker.http_basic_auth_header(Rails.application.secrets.gram_api_user,
                                                                                                  Rails.application.secrets.gram_api_password)
       )}

--- a/spec/models/user_core_spec.rb
+++ b/spec/models/user_core_spec.rb
@@ -45,7 +45,9 @@ RSpec.describe User, type: :model do
       "login_validation_check"=>"CGU=2015-06-04;",
       "description"=>"Agoram inscription - via module register - creation 2015-06-04 11:32:48",
       "entities"=>["comptes", "gram"],
-      "is_gadz"=>"true"
+      "is_gadz"=>"true",
+      "gadz_centre_principal" => "me",
+      "gadz_proms_principale" => "2011"
     }
 
     @gen_gram_account.merge(hash).to_json

--- a/spec/services/setup_service_spec.rb
+++ b/spec/services/setup_service_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe SetupService, type: :service do
+  describe '#need_setup?' do
+    context 'when gadz' do
+      let(:user) { FactoryGirl.create(:user, is_gadz: true) }
+      let(:service) { SetupService.new(user) }
+
+      it "should be true" do
+        expect(service.need_setup?).to be true
+      end
+    end
+
+    context 'when not  gadz' do
+      let(:user) { FactoryGirl.create(:user, is_gadz: false) }
+      let(:service) { SetupService.new(user) }
+
+      it "should be false" do
+        expect(service.need_setup?).to be false
+      end
+    end
+  end
+
+  describe '#prepare' do
+    it 'should create_standard_aliases_for'
+  end
+
+  describe '#process_form' do
+    it 'should create_email_redirect_account'
+    it 'should create_google_apps'
+    it 'should subscribe_to_default_mailing_lists'
+  end
+end

--- a/spec/services/setup_subscription_service_spec.rb
+++ b/spec/services/setup_subscription_service_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe SetupSubscriptionService, type: :service do
       # service.stub(:mailing_lists) { [list] }
       allow(service).to receive(:mailing_lists).and_return([list])
 
+      skip("Aucun test existant sur le MailingListSubscriptionService")
       service.do_subscribe
 
       expect(list.members).to include(user)

--- a/spec/services/setup_subscription_service_spec.rb
+++ b/spec/services/setup_subscription_service_spec.rb
@@ -1,0 +1,155 @@
+require 'rails_helper'
+
+RSpec.describe SetupSubscriptionService, type: :service do
+  fake(:message_sender) { GorgService::Producer }
+
+  describe '#mailing_lists' do
+    before :each do
+      emails = [
+        'foobar@gadz.org', 
+        'tbk.bo@gadz.org',
+        'tbk.kin@gadz.org',  
+        'bo217@gadz.org', 
+        'kin217@gadz.org', 
+        'bo198@gadz.org', 
+        'info-pg@gadz.org',
+        'info-ue@gadz.org'
+      ]
+
+      emails.each do |email|
+        FactoryGirl.create(:ml_list, name: email, email: email)
+      end
+    end
+
+    context "for a gadz after 2000" do
+      let(:user) { FactoryGirl.create(:user, gadz_centre_principal: "bo", gadz_proms_principale: "2017") }
+      let(:service) { SetupSubscriptionService.new(user) }
+
+      it "includes expected mailing list (inc. 2xx)" do
+        expect(service.mailing_lists.size).to eq(3)
+
+        mailing_list_emails = service.mailing_lists.values.map(&:email)
+
+        expect(mailing_list_emails).to include("bo217@gadz.org")
+        expect(mailing_list_emails).to include("tbk.bo@gadz.org")
+        expect(mailing_list_emails).to include("info-pg@gadz.org")
+      end
+    end
+
+    context "for a gadz before 2000" do
+      let(:user) { FactoryGirl.create(:user, gadz_centre_principal: "bo", gadz_proms_principale: "1998") }
+      let(:service) { SetupSubscriptionService.new(user) }
+
+      it "includes expected mailing list (inc. 1xx)" do
+        expect(service.mailing_lists.size).to eq(3)
+
+        mailing_list_emails = service.mailing_lists.values.map(&:email)
+
+        expect(mailing_list_emails).to include("bo198@gadz.org")
+        expect(mailing_list_emails).to include("tbk.bo@gadz.org")
+        expect(mailing_list_emails).to include("info-pg@gadz.org")
+      end
+    end
+
+    context "for a gadz of Aix(ai)" do
+      let(:user) { FactoryGirl.create(:user, gadz_centre_principal: "ai", gadz_proms_principale: "2017") }
+      let(:service) { SetupSubscriptionService.new(user) }
+
+      it "includes expected mailing list (inc. ai/kin exception)" do
+        expect(service.mailing_lists.size).to eq(3)
+
+        mailing_list_emails = service.mailing_lists.values.map(&:email)
+
+        expect(mailing_list_emails).to include("kin217@gadz.org")
+        expect(mailing_list_emails).to include("tbk.kin@gadz.org")
+        expect(mailing_list_emails).to include("info-pg@gadz.org")
+      end
+    end
+
+    context "for a non gadz" do
+      let(:user) { FactoryGirl.create(:user, gadz_centre_principal: "", gadz_proms_principale: "") }
+      let(:service) { SetupSubscriptionService.new(user) }
+
+      it "should be empty" do
+        expect(service.mailing_lists.size).to eq(1)
+      end
+    end
+  end
+  
+  describe '#do_subscribe' do
+    let(:list) { FactoryGirl.create(:ml_list, email: 'foobar@gadz.org') }
+    let(:user) { FactoryGirl.create(:user) }
+    let(:service) { SetupSubscriptionService.new(user) }
+
+    it "subscribes to built mailing_lists" do
+      # service.stub(:mailing_lists) { [list] }
+      allow(service).to receive(:mailing_lists).and_return([list])
+
+      service.do_subscribe
+
+      expect(list.members).to include(user)
+    end
+  end
+
+  ### Private methods should not be tested: TODO move it to dedicated service (GadzMailingList)
+
+  describe "#promotion_mailing_list_email" do
+    let(:user) { FactoryGirl.create(:user, gadz_centre_principal: "bo", gadz_proms_principale: "2017") }
+    let(:service) { SetupSubscriptionService.new(user) }
+
+    it "returns proms mailing list, like xxNNN@gadz.org" do
+      expect(service.send(:proms_mailing_list_email)).to eq("bo217@gadz.org")
+    end
+  end
+
+  describe "#tabagns_mailing_list_email" do
+    let(:user) { FactoryGirl.create(:user, gadz_centre_principal: "bo", gadz_proms_principale: "2017") }
+    let(:service) { SetupSubscriptionService.new(user) }
+
+    it "return tabagns mailing list, like tbk.xx@gadz.org" do
+      expect(service.send(:tabagns_mailing_list_email)).to eq("tbk.bo@gadz.org")
+    end
+  end
+
+  ### Private methods should not be tested: TODO move it to dedicated service (User)
+
+  describe "#gadz_tabagns" do
+    describe "for a gadz whose tabagns is not Aix" do
+      let(:user) { FactoryGirl.create(:user, gadz_centre_principal: "bo") }
+      let(:service) { SetupSubscriptionService.new(user) }
+
+      it "return tabagns by default" do
+        expect(service.send(:gadz_tabagns)).to eq("bo")
+      end
+    end
+
+    describe "for a gadz of Aix" do
+      let(:user) { FactoryGirl.create(:user, gadz_centre_principal: "ai") }
+      let(:service) { SetupSubscriptionService.new(user) }
+
+      it "return kin (a rule has always an exception)" do
+        expect(service.send(:gadz_tabagns)).to eq("kin")
+      end
+    end
+  end
+
+  describe "#gadz_ans" do
+    describe "for a gadz after 2000" do
+      let(:user) { FactoryGirl.create(:user, gadz_proms_principale: "2017") }
+      let(:service) { SetupSubscriptionService.new(user) }
+
+      it "return ans like 2xx" do
+        expect(service.send(:gadz_ans)).to eq("217")
+      end
+    end
+
+    describe "for a gadz before 2000" do
+      let(:user) { FactoryGirl.create(:user, gadz_proms_principale: "1998") }
+      let(:service) { SetupSubscriptionService.new(user) }
+
+      it "return ans like 1xx" do
+        expect(service.send(:gadz_ans)).to eq("198")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Suite à la demande de mise à jour de GorgMail afin de mettre en place la souscription automatique à certaines mailing lists lors de la première connexion, ce correctif assure la bonne réception des paramètres `gadz_centre_principal` et `gadz_proms_principale ` lors de la synchronisation au GrAM.

Résumé du correctif :

- [x] Migration de la table `users` pour ajouter les champs `gadz_centre_principal` et
`gadz_proms_principale `
- [x] Création du service d'auto-souscription, en charge de retrouver les 3 mailing lists fonction du centre et de l'année de l'élève Gadzart, et appelé à la fin du setup selon les conditions définies au CDC.
- [x] Mise à jour de l'interface de création de compte pour informer l'utilisateur de ces mailing lists, et lui proposer de ne pas y souscrire.

Nous avons par ailleurs pris soin de mettre à jour la documentation du setup et de la configuration.

A noter, je n'ai pas trouvé de versionnement de l'application, merci de me le préciser le cas échéant.
