### PR TITLE
Fix mailing list form to enable archive checkbox

### DIFF
--- a/app/views/ml/lists/_form.html.haml
+++ b/app/views/ml/lists/_form.html.haml
@@ -16,7 +16,7 @@
     = f.select :inscription_policy, Ml::List.inscription_policy_list
     = f.input :messsage_header
     = f.input :message_footer
-    = f.input :is_archived
+    = f.input :is_archived, :label_html => { :style => "pointer-events: all" }
     = f.input :custom_reply_to
     = f.input :default_message_deny_notification_text
     = f.input :msg_welcome


### PR DESCRIPTION
@Blaked84 Ce correctif rétablit le fonctionnement de l'archivage d'une mailing list depuis le formulaire.
Il s'agit d'une modification CSS permettant à nouveau le click sur la case-à-cocher concernée, 
en surchargeant localement la directive globale définie dans [stylesheets/autoload/forms.scss0#L43](https://github.com/gadzorg/gorg_mail/blob/master/app/assets/stylesheets/autoload/forms.scss0#L43)