### PR TITLE
Alias: mailing list relation is optional

### DIFF
--- a/app/models/alias.rb
+++ b/app/models/alias.rb
@@ -23,7 +23,7 @@
 
 class Alias < ApplicationRecord
   belongs_to :email_virtual_domain,  class_name: "EmailVirtualDomain"
-  belongs_to :ml_list, :class_name => 'Ml::List', :foreign_key => "list_id"
+  belongs_to :ml_list, :class_name => 'Ml::List', :foreign_key => "list_id", optional: true
 
   validates_presence_of :email_virtual_domain
 

--- a/features/mailing_lists/subscribe_mailing_list.feature
+++ b/features/mailing_lists/subscribe_mailing_list.feature
@@ -10,5 +10,5 @@ Feature: Register to a Mailinglists
     And I visit to mailing lists index
     When I click "M'inscrire" button in "[data-list-name='Fun Public Group']"
     Then I becomes a member of "Fun Public Group"
-    And "my_address@gadz.org" receive an email with object "Vous avez rejoins le groupe de discussion \"Fun Public Group\""
+    And "my_address@gadz.org" receive an email with object "Vous avez rejoint le groupe de discussion \"Fun Public Group\""
     And this email contains a text matching /\/ml\/lists\/[0-9]+/leave\/[0-9]+/


### PR DESCRIPTION
Should remove the required field _mailing list_ in Alias forms.