### PR TITLE
Jira 206: mailing unsubscribe (decline) invitation link

### DIFF
--- a/app/assets/stylesheets/materialize-fix.scss
+++ b/app/assets/stylesheets/materialize-fix.scss
@@ -37,7 +37,10 @@ input[type="submit"] {
 }
 
 
-.modal.bottom-sheet-big
-{
+.modal.bottom-sheet-big {
   max-height: 84%;
+}
+
+.input-field label {
+  pointer-events: auto;
 }

--- a/app/controllers/ml/external_invitation_controller.rb
+++ b/app/controllers/ml/external_invitation_controller.rb
@@ -2,7 +2,7 @@ class Ml::ExternalInvitationController < ApplicationController
 
   layout 'no-menu'
 
-  before_action :set_token, only: [:accept_invitation, :accept_cgu]
+  before_action :set_token, only: [:accept_invitation, :decline_invitation, :accept_cgu]
   rescue_from ExternalInvitationService::InvalidToken, with: :unknown_token
 
   def accept_cgu
@@ -24,6 +24,13 @@ class Ml::ExternalInvitationController < ApplicationController
     @cgu_retry=params[:cgu_retry]
     @list=service.list
     @email=service.external_email.email
+  end
+
+  def decline_invitation
+    service = ExternalInvitationService.initialize_from_token(@token)
+    service.decline_invitation
+
+    @list = service.list
   end
 
   def set_token

--- a/app/controllers/ml/lists_controller.rb
+++ b/app/controllers/ml/lists_controller.rb
@@ -200,6 +200,22 @@ class Ml::ListsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def ml_list_params
-      params.require(:ml_list).permit(:name, :email, :description, :aliases, :diffusion_policy, :inscription_policy, :is_public, :messsage_header, :message_footer, :is_archived, :custom_reply_to, :default_message_deny_notification_text, :msg_welcome, :msg_goodbye, :is_archived, :message_max_bytes_size, :group_uuid)
+      params.require(:ml_list).permit(:name,
+                                      :email,
+                                      :description,
+                                      :aliases,
+                                      :diffusion_policy,
+                                      :inscription_policy,
+                                      :is_public,
+                                      :messsage_header,
+                                      :message_footer,
+                                      :is_archived,
+                                      :custom_reply_to,
+                                      :default_message_deny_notification_text,
+                                      :msg_welcome,
+                                      :msg_goodbye,
+                                      :message_max_bytes_size,
+                                      :group_uuid,
+                                    )
     end
 end

--- a/app/services/external_invitation_service.rb
+++ b/app/services/external_invitation_service.rb
@@ -47,6 +47,11 @@ class ExternalInvitationService
     end
   end
 
+  def decline_invitation
+    list.remove_email(external_email)
+    token.set_used # will be destroyed by mailing callback anyway
+  end
+
 
   def self.initialize_from_email(email: nil, list: nil)
     self.new(email:email, list:list)

--- a/app/views/external_invitation_mailer/send_invitation.html.haml
+++ b/app/views/external_invitation_mailer/send_invitation.html.haml
@@ -1,8 +1,8 @@
 %p Bonjour,
 
-%p Vous êtes invité à rejoindre la liste de discussion Gadz.org "#{@list.name}"
+%p Vous êtes invité(e) à rejoindre la liste de discussion Gadz.org "#{@list.name}"
 
-%p En acceptant cette invitation, vous receverez les mails envoyé à g199@poubs.org et vous pourrez également échanger avec les autres membre de cette liste en écrivant à cette même adresse
+%p En acceptant cette invitation, vous recevrez les emails envoyés à <b>#{@list.name}</b> sur votre adresse <b>#{@email}</b>. Vous pourrez également échanger avec les autres membre de cette liste en écrivant à <b>#{@list.email}</b>.
 
 .txtcenter.bouton.bouton_bleu
   =link_to "Accepter l'invitation", ml_accept_external_invitation_url(@token.token) ,:class => "bouton bouton_orange_1 txtcenter"
@@ -12,4 +12,4 @@
 %p=ml_accept_external_invitation_url(@token.token)
 
 %p.small
-  Si vous ne souhaitez pas donner suite à cette invitation, vous pouvez simplement l'ignorer
+  Si vous ne souhaitez pas donner suite à cette invitation, vous pouvez simplement l'ignorer.

--- a/app/views/external_invitation_mailer/send_invitation.html.haml
+++ b/app/views/external_invitation_mailer/send_invitation.html.haml
@@ -11,5 +11,7 @@
   Si ce lien ne fonctionne pas, copiez l'adresse suivante puis collez-la dans une nouvelle fenêtre de navigateur :
 %p=ml_accept_external_invitation_url(@token.token)
 
+%br
 %p.small
-  Si vous ne souhaitez pas donner suite à cette invitation, vous pouvez simplement l'ignorer.
+  Autrement, vous pouvez
+  = link_to "décliner cette invitation", ml_decline_external_invitation_url(@token.token)

--- a/app/views/external_invitation_mailer/send_invitation.text.haml
+++ b/app/views/external_invitation_mailer/send_invitation.text.haml
@@ -1,8 +1,12 @@
 Bonjour,
-
-Vous êtes invitez à rejoindre la liste de discussion Gadz.org "#{@list.name}"
-
-Si ce lien ne fonctionne pas, copiez l'adresse suivante puis collez-la dans une nouvelle fenêtre de navigateur :
-=ml_accept_external_invitation_url(@token.token)
-
-Si vous ne souhaitez pas donner suite à cette invitation, vous pouvez simplement l'ignorer
+\
+Vous êtes invité(e) à rejoindre la liste de discussion Gadz.org "#{@list.name}".
+\
+En acceptant cette invitation, vous recevrez les emails envoyés à #{@list.name}
+sur votre adresse #{@email}.
+Vous pourrez également échanger avec les autres membre de cette liste
+en écrivant à #{@list.email}.
+\
+Pour accepter l'invitation, cliquez sur le lien ci-dessous ou copiez/collez-le
+dans votre navigateur :
+= ml_accept_external_invitation_url(@token.token)

--- a/app/views/external_invitation_mailer/send_invitation.text.haml
+++ b/app/views/external_invitation_mailer/send_invitation.text.haml
@@ -10,3 +10,8 @@ en écrivant à #{@list.email}.
 Pour accepter l'invitation, cliquez sur le lien ci-dessous ou copiez/collez-le
 dans votre navigateur :
 = ml_accept_external_invitation_url(@token.token)
+\
+\
+\
+Autrement, vous pouvez décliner cette invitation :
+= ml_decline_external_invitation_url(@token.token)

--- a/app/views/ml/external_invitation/decline_invitation.html.haml
+++ b/app/views/ml/external_invitation/decline_invitation.html.haml
@@ -1,0 +1,13 @@
+%p#notice= notice
+
+%div.center-align
+  %h2
+    %i.zmdi.zmdi-thumb-up.icon-padding-list
+
+  %p Nous avons bien enregistré le refus de votre invitation à <b>#{@list.name}</b>.
+
+  %br
+  %br
+
+  %p.small
+    = link_to 'Gérer vos inscriptions', mailinglists_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   end
   namespace :ml do
     get 'lists/invitations/:token', to: 'external_invitation#accept_invitation', as: :accept_external_invitation
+    get 'lists/invitations/decline/:token', to: 'external_invitation#decline_invitation', as: :decline_external_invitation
     post 'lists/invitations/:token', to: 'external_invitation#accept_cgu'
 
     resources :lists do
@@ -33,7 +34,7 @@ Rails.application.routes.draw do
   resources :aliases
   resources :postfix_blacklists, path: :blacklist, except: [:show]
   resources :email_virtual_domains, path: :domains, except: [:show]
-  
+
   devise_for :users, :controllers => {
     :omniauth_callbacks => "users/omniauth_callbacks",
     :sessions => "users/sessions",
@@ -74,7 +75,7 @@ Rails.application.routes.draw do
     resources :email_source_accounts, only: [:index, :show, :create,:update,:destroy] do
       get :set_as_primary
     end
-    
+
     resources :email_redirect_accounts, only: [:index, :show, :create,:update,:destroy] do
       # get :flag
       get "flag/:flag", to: "email_redirect_accounts#flag", as: :flag, defaults: { format: 'js' }

--- a/features/mailing_lists/invit_external.feature
+++ b/features/mailing_lists/invit_external.feature
@@ -42,6 +42,15 @@ Feature: Invite a user without account to join a mailing list
     And "external@example.com" becomes subscribed to the mailinglist "my_mailing_list" as an active external member
     And the token "some_token" is used
 
+
+  Scenario: I decline the invitation
+    Given "external@example.com" was invited to join the mailing list named "my_mailing_list" with token "some_token"
+    When I visit "/ml/lists/invitations/decline/some_token"
+    Then the page contains "refus"
+    Then the page contains "my_mailing_list"
+    And "external@example.com" is not an external member of "my_mailing_list"
+    And the token "some_token" is destroyed
+
   Scenario: Admin cancel the invitation before user accept it
     Given "external@example.com" was invited to join the mailing list named "my_mailing_list" with token "some_token"
     When external member "external@example.com" is deleted from "my_mailing_list"

--- a/features/mailing_lists/subscribe_mailing_list.feature
+++ b/features/mailing_lists/subscribe_mailing_list.feature
@@ -10,5 +10,5 @@ Feature: Register to a Mailinglists
     And I visit to mailing lists index
     When I click "M'inscrire" button in "[data-list-name='Fun Public Group']"
     Then I becomes a member of "Fun Public Group"
-    And "my_address@gadz.org" receive an email with object "Vous avez rejoins le groupe de discussion \"Fun Public Group\""
+    And "my_address@gadz.org" receive an email with object "Vous avez rejoint le groupe de discussion \"Fun Public Group\""
     And this email contains a text matching /\/ml\/lists\/[0-9]+/leave\/[0-9]+/

--- a/features/step_definitions/tokens.rb.rb
+++ b/features/step_definitions/tokens.rb.rb
@@ -32,3 +32,7 @@ end
 And(/^the token "([^"]*)" is used$/) do |arg|
   expect(Token.find_by(token: arg)).to be_used
 end
+
+And(/^the token "([^"]*)" is destroyed$/) do |arg|
+  expect(Token.find_by(token: arg)).to be_nil
+end


### PR DESCRIPTION
• Intègre un lien pour refuser l'invitation à une mailing list
• Améliore/corrige le texte de l'email 

Closes GORGMAIL-206
https://jira.gadz.org/browse/GORGMAIL-206


NB: A merger **après** https://github.com/gadzorg/gorg_mail/pull/148 (cette branche est basée dessus pour corriger les checkbox)


<img width="500" alt="email-content" src="https://user-images.githubusercontent.com/150279/76776565-35523200-67a7-11ea-9430-b47483c9fda1.png">

<img width="500" alt="decline-confirmation" src="https://user-images.githubusercontent.com/150279/76776579-397e4f80-67a7-11ea-940c-939b142425bf.png">

